### PR TITLE
Fix failing tests

### DIFF
--- a/tests/compile-error/expected_results.json
+++ b/tests/compile-error/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "error",
   "message": "/usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: compile_error_test.o: in function `test_add':\n/mnt/exercism-iteration/compile_error_test.c:14: undefined reference to `add'\ncollect2: error: ld returned 1 exit status\nmake: *** [Makefile:29: tests] Error 1\n",
   "tests": []

--- a/tests/multiple-tests-with-all-passes/expected_results.json
+++ b/tests/multiple-tests-with-all-passes/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "message": null,
   "tests": [

--- a/tests/multiple-tests-with-multiple-fails/expected_results.json
+++ b/tests/multiple-tests-with-multiple-fails/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "message": null,
   "tests": [

--- a/tests/multiple-tests-with-segfault/expected_results.json
+++ b/tests/multiple-tests-with-segfault/expected_results.json
@@ -1,6 +1,7 @@
 {
+  "version": 2,
   "status": "error",
-  "message": "make: *** [Makefile:26: all] Segmentation fault (core dumped)\n",
+  "message": "make: *** [Makefile:26: all] Segmentation fault\n",
   "tests": [
     {
       "name": "test_add",

--- a/tests/multiple-tests-with-single-fail/expected_results.json
+++ b/tests/multiple-tests-with-single-fail/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "message": null,
   "tests": [

--- a/tests/multiple-tests-with-test-output-exceeding-limit/expected_results.json
+++ b/tests/multiple-tests-with-test-output-exceeding-limit/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "message": null,
   "tests": [

--- a/tests/multiple-tests-with-test-output/expected_results.json
+++ b/tests/multiple-tests-with-test-output/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "message": null,
   "tests": [

--- a/tests/single-test-that-fails/expected_results.json
+++ b/tests/single-test-that-fails/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "fail",
   "message": null,
   "tests": [

--- a/tests/single-test-that-passes/expected_results.json
+++ b/tests/single-test-that-passes/expected_results.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "status": "pass",
   "message": null,
   "tests": [

--- a/tests/single-test-that-segfaults/expected_results.json
+++ b/tests/single-test-that-segfaults/expected_results.json
@@ -1,5 +1,6 @@
 {
+  "version": 2,
   "status": "error",
-  "message": "make: *** [Makefile:26: all] Segmentation fault (core dumped)\n",
+  "message": "make: *** [Makefile:26: all] Segmentation fault\n",
   "tests": []
 }


### PR DESCRIPTION
The tests were failing due to a missing `"version": 2` key in the `expected_results.json` file.