### PR TITLE
bump alpine to 3.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.5
+FROM alpine:3.23.5@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 RUN apk add --no-cache coreutils gcc libc-dev make nasm python3
 WORKDIR /opt/test-runner
 COPY bin/run.sh bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.3
+FROM alpine:3.23.5
 RUN apk add --no-cache coreutils gcc libc-dev make nasm python3
 WORKDIR /opt/test-runner
 COPY bin/run.sh bin/

--- a/tests/compile-error/expected_results.json
+++ b/tests/compile-error/expected_results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: compile_error_test.o: in function `test_add':\n/opt/test-runner/tests/compile-error/compile_error_test.c:14: undefined reference to `add'\ncollect2: error: ld returned 1 exit status\nmake: *** [Makefile:29: tests] Error 1\n",
+  "message": "/usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: compile_error_test.o: in function `test_add':\n/opt/test-runner/tests/compile-error/compile_error_test.c:14:(.text+0x1d): undefined reference to `add'\ncollect2: error: ld returned 1 exit status\nmake: *** [Makefile:29: tests] Error 1\n",
   "tests": []
 }


### PR DESCRIPTION
This bumps Alpine to 3.23.5. Alpine 3.18 reached end of life on [2025-05-09](https://alpinelinux.org/releases/).

I tested this upgrade against all example/exemplar solutions on the x86-64-assembly track. Everything passed.

I chose 3.23 because it ships with [NASM-2.16.03](https://pkgs.alpinelinux.org/packages?name=nasm&branch=v3.23), which is very close to the version that comes with [Ubuntu-24.04](https://launchpad.net/ubuntu/+source/nasm), the Ubuntu version currently used by CI on the x86-64-assembly track.

Once we change to Ubuntu-26.04, which comes with NASM-3.01, we may consider bumping Alpine again to 3.24 (also with NASM-3.01) or a more recent version, so the test runner and CI stay aligned.