### PR TITLE
bump alpine to 3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.5@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk add --no-cache coreutils gcc libc-dev make nasm python3
 WORKDIR /opt/test-runner
 COPY bin/run.sh bin/


### PR DESCRIPTION
This is to keep NASM version in sync with Ubuntu 26.04 used in workflows, after the update in https://github.com/exercism/x86-64-assembly/pull/479

